### PR TITLE
Fixed a typo in Japanese on page 14

### DIFF
--- a/src/contents/14.jp.tsx
+++ b/src/contents/14.jp.tsx
@@ -140,7 +140,7 @@ export default () => (
                       <P>
                         そうすることで、
                         <Highlight>
-                          どいうった経緯で最終的に「
+                          どういった経緯で最終的に「
                           <H args={{ name: 'repeatFeature' }} />
                           」と同じになるのか
                         </Highlight>


### PR DESCRIPTION
Hello, I enjoyed reading this.
I found a Japanese typo in it, so I fixed it.
'どいうった' ==> 'どういった'

https://yj.chibicode.com/14/
<img width="1680" alt="スクリーンショット 2020-04-18 16 19 43" src="https://user-images.githubusercontent.com/43288418/79630932-75367b80-8190-11ea-8608-bea8da327db6.png">
